### PR TITLE
Updateversion

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,6 @@ pipeline:
     image: plugins/docker
     secrets: [ docker_username, docker_password ]
     repo: wintercircle/drone-rancher
-		tag: ${DRONE_TAG}
+    tag: ${DRONE_TAG}
     when:
       event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,3 +22,10 @@ pipeline:
     tag: latest
     when:
       branch: master
+  docker-dev:
+    image: plugins/docker
+    secrets: [ docker_username, docker_password ]
+    repo: wintercircle/drone-rancher
+    tag: dev
+    when:
+      branch: development

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,3 +6,12 @@ plugin:
   labels:
     - orchestration
     - deploy
+
+pipeline:
+  docker:
+    image: plugins/docker
+    secrets: [ docker_username, docker_password ]
+    repo: wintercircle/drone-rancher
+		tag: ${DRONE_TAG}
+    when:
+      event: tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,3 +15,10 @@ pipeline:
     tag: ${DRONE_TAG}
     when:
       event: tag
+  docker:
+    image: plugins/docker
+    secrets: [ docker_username, docker_password ]
+    repo: wintercircle/drone-rancher
+    tag: latest
+    when:
+      branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ ENV RANCHER_COMPOSE_VERSION=0.12.5
 RUN mkdir -p /opt/drone
 WORKDIR /opt/drone
 
-#https://github.com/rancher/rancher-compose/releases/download/v0.12.5/rancher-compose-linux-amd64-v0.12.5.tar.gz
 
 RUN apk add openssl ca-certificates && \
-    #wget -O rancher-compose.tar.gz https://github.com/rancher/rancher-compose/releases/download/v$RANCHER_COMPOSE_VERSION/rancher-compose-linux-amd64-v$RANCHER_COMPOSE_VERSION.tar.gz && \
-    wget -O rancher-compose.tar.gz  https://github.com/rancher/rancher-compose/releases/download/v0.12.5/rancher-compose-linux-amd64-v0.12.5.tar.gz  && \
+    wget -O rancher-compose.tar.gz https://github.com/rancher/rancher-compose/releases/download/v$RANCHER_COMPOSE_VERSION/rancher-compose-linux-amd64-v$RANCHER_COMPOSE_VERSION.tar.gz && \
     tar -zxvf rancher-compose.tar.gz && \
     mv ./rancher-compose-v$RANCHER_COMPOSE_VERSION/rancher-compose /usr/bin/ && \
     rm -rf rancher-compose*

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 #
 #     docker build --rm=true -t dangerfarms/drone-rancher .
 
-FROM gliderlabs/alpine:3.2
-MAINTAINER Lewis Taylor <lewis@dangerfarms.com>
+FROM gliderlabs/alpine:3.8
 
 ENV VERSION=0.12.5
 ENV RANCHER_COMPOSE_VERSION=0.12.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Deploy builds to a Rancher orchestrated stack using rancher-compose
 #
 #     docker build --rm=true -t dangerfarms/drone-rancher .
-
-FROM gliderlabs/alpine:3.8
+#gliderlabs/
+FROM alpine:latest
 
 ENV VERSION=0.12.5
 ENV RANCHER_COMPOSE_VERSION=0.12.5
@@ -12,14 +12,14 @@ WORKDIR /opt/drone
 
 #https://github.com/rancher/rancher-compose/releases/download/v0.12.5/rancher-compose-linux-amd64-v0.12.5.tar.gz
 
-RUN apk-install openssl ca-certificates && \
+RUN apk add openssl ca-certificates && \
     #wget -O rancher-compose.tar.gz https://github.com/rancher/rancher-compose/releases/download/v$RANCHER_COMPOSE_VERSION/rancher-compose-linux-amd64-v$RANCHER_COMPOSE_VERSION.tar.gz && \
     wget -O rancher-compose.tar.gz  https://github.com/rancher/rancher-compose/releases/download/v0.12.5/rancher-compose-linux-amd64-v0.12.5.tar.gz  && \
     tar -zxvf rancher-compose.tar.gz && \
     mv ./rancher-compose-v$RANCHER_COMPOSE_VERSION/rancher-compose /usr/bin/ && \
     rm -rf rancher-compose*
 
-RUN apk-install python3
+RUN apk add python3
 
 COPY requirements.txt /opt/drone/
 RUN pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 FROM gliderlabs/alpine:3.2
 MAINTAINER Lewis Taylor <lewis@dangerfarms.com>
 
-ENV VERSION=1.0.0
-ENV RANCHER_COMPOSE_VERSION=0.12.1
+ENV VERSION=0.12.5
+ENV RANCHER_COMPOSE_VERSION=0.12.5
 
 RUN mkdir -p /opt/drone
 WORKDIR /opt/drone

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ ENV RANCHER_COMPOSE_VERSION=0.12.5
 RUN mkdir -p /opt/drone
 WORKDIR /opt/drone
 
+#https://github.com/rancher/rancher-compose/releases/download/v0.12.5/rancher-compose-linux-amd64-v0.12.5.tar.gz
+
 RUN apk-install openssl ca-certificates && \
-    wget -O rancher-compose.tar.gz https://github.com/rancher/rancher-compose/releases/download/v$RANCHER_COMPOSE_VERSION/rancher-compose-linux-amd64-v$RANCHER_COMPOSE_VERSION.tar.gz && \
+    #wget -O rancher-compose.tar.gz https://github.com/rancher/rancher-compose/releases/download/v$RANCHER_COMPOSE_VERSION/rancher-compose-linux-amd64-v$RANCHER_COMPOSE_VERSION.tar.gz && \
+    wget -O rancher-compose.tar.gz  https://github.com/rancher/rancher-compose/releases/download/v0.12.5/rancher-compose-linux-amd64-v0.12.5.tar.gz  && \
     tar -zxvf rancher-compose.tar.gz && \
     mv ./rancher-compose-v$RANCHER_COMPOSE_VERSION/rancher-compose /usr/bin/ && \
     rm -rf rancher-compose*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Overview
 
 Execute from the working directory:
 
+```
 docker run --rm \
   -e PLUGIN_COMPOSE_FILE=docker-compose.yml \
   -e PLUGIN_RANCHER_FILE=rancher-compose.yml \
@@ -26,6 +27,7 @@ docker run --rm \
   -e RANCHER_ACCESS_KEY=key \
   -e RANCHER_SECRET_KEY=secret \
   wintercircle/drone-rancher
+```
 
 
 License

--- a/README.rst
+++ b/README.rst
@@ -3,77 +3,29 @@ drone-rancher
 
 Deploy builds to a Rancher orchestrated stack using rancher-compose
 
+Build
+-----
+
+docker build -t wintercircle/drone-rancher .
+docker push wintercircle/drone-rancher
+
 Overview
 --------
 
-Run the plugin directly after installing requirements:
+Execute from the working directory:
 
-.. code-block:: bash
-
-    python plugin/main.py <<EOF
-    {
-        "repo" : {
-            "owner": "foo",
-            "name": "bar",
-            "full_name": "foo/bar"
-        },
-        "system": {
-            "link_url": "http://drone.mycompany.com"
-        },
-        "build" : {
-            "number": 22,
-            "status": "success",
-            "started_at": 1421029603,
-            "finished_at": 1421029813,
-            "commit": "9f2849d5",
-            "branch": "master",
-            "message": "Update the Readme",
-            "author": "johnsmith",
-            "author_email": "john.smith@gmail.com"
-        },
-        "vargs": {
-            "room_auth_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-            "room_id_or_name": 1234567,
-            "message_notify": true
-        }
-    }
-    EOF
-
-Docker
-------
-
-Alternatively, run the plugin directly from a built Docker image:
-
-.. code-block:: bash
-
-    docker run -i dangerfarms/drone-rancher <<EOF
-    {
-        "repo" : {
-            "owner": "foo",
-            "name": "bar",
-            "full_name": "foo/bar"
-        },
-        "system": {
-            "link_url": "http://drone.mycompany.com"
-        },
-        "build" : {
-            "number": 22,
-            "status": "success",
-            "started_at": 1421029603,
-            "finished_at": 1421029813,
-            "commit": "9f2849d5",
-            "branch": "master",
-            "message": "Update the Readme",
-            "author": "johnsmith",
-            "author_email": "john.smith@gmail.com"
-        },
-        "vargs": {
-            "room_auth_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-            "room_id_or_name": 1234567,
-            "message_notify": true
-        }
-    }
-    EOF
+docker run --rm \
+  -e PLUGIN_COMPOSE_FILE=docker-compose.yml \
+  -e PLUGIN_RANCHER_FILE=rancher-compose.yml \
+  -e PLUGIN_SERVICES=web \
+  -e PLUGIN_FORCE=true \
+  -e PLUGIN_CONFIRM=true \
+  -e PLUGIN_ALWAYS_PULL=true \
+  -e PLUGIN_URL=https://rancher.url/ \
+  -e DRONE_REPO_NAME=my/repo \
+  -e RANCHER_ACCESS_KEY=key \
+  -e RANCHER_SECRET_KEY=secret \
+  wintercircle/drone-rancher
 
 
 License

--- a/main.py
+++ b/main.py
@@ -27,7 +27,6 @@ def main():
         stack = '{}-{}'.format(stack, os.environ["DRONE_TAG"])
 
     services = os.environ.get("PLUGIN_SERVICES", '')
-    --batch-size
     force_upgrade = str_to_bool(os.environ.get('PLUGIN_FORCE', 'false'))
     confirm_upgrade = str_to_bool(os.environ.get('PLUGIN_CONFIRM', 'false'))
     pull = str_to_bool(os.environ.get('PLUGIN_ALWAYS_PULL', 'false'))

--- a/main.py
+++ b/main.py
@@ -21,7 +21,11 @@ def main():
     # Optional fields
     compose_file = os.environ["PLUGIN_COMPOSE_FILE"]
     rancher_file = os.environ["PLUGIN_RANCHER_FILE"]
-    stack = os.environ["DRONE_REPO_NAME"]
+    use_tag_in_stack = str_to_bool(os.environ.get('PLUGIN_USE_TAG_IN_STACK', 'false'))
+    stack = os.environ["PLUGIN_STACK"] or os.environ["DRONE_REPO_NAME"]
+    if use_tag_in_stack and os.environ["DRONE_TAG"]:
+        stack.append('-', os.environ["DRONE_TAG"])
+
     services = os.environ.get("PLUGIN_SERVICES", '')
     force_upgrade = str_to_bool(os.environ.get('PLUGIN_FORCE', 'false'))
     confirm_upgrade = str_to_bool(os.environ.get('PLUGIN_CONFIRM', 'false'))

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def main():
     use_tag_in_stack = str_to_bool(os.environ.get('PLUGIN_USE_TAG_IN_STACK', 'false'))
     stack = os.environ["PLUGIN_STACK"] or os.environ["DRONE_REPO_NAME"]
     if use_tag_in_stack and os.environ["DRONE_TAG"]:
-        stack.append('-', os.environ["DRONE_TAG"])
+        stack = '{}-{}'.format(stack, os.environ["DRONE_TAG"])
 
     services = os.environ.get("PLUGIN_SERVICES", '')
     force_upgrade = str_to_bool(os.environ.get('PLUGIN_FORCE', 'false'))

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ def main():
         stack = '{}-{}'.format(stack, os.environ["DRONE_TAG"])
 
     services = os.environ.get("PLUGIN_SERVICES", '')
+    --batch-size
     force_upgrade = str_to_bool(os.environ.get('PLUGIN_FORCE', 'false'))
     confirm_upgrade = str_to_bool(os.environ.get('PLUGIN_CONFIRM', 'false'))
     pull = str_to_bool(os.environ.get('PLUGIN_ALWAYS_PULL', 'false'))
@@ -38,7 +39,7 @@ def main():
 
     try:
         base_rancher_compose_cmd = \
-            "rancher-compose {rancher_file} {compose_file} {stack} up -d {{upgrade}} {{pull}} {{confirm}} {services}".format(
+            "rancher-compose {rancher_file} {compose_file} {stack} up -d --batch-size 1 {{upgrade}} {{pull}} {{confirm}} {services}".format(
                 rancher_file=create_arg_flag("-r", rancher_file),
                 compose_file=create_arg_flag("-f", compose_file),
                 stack=create_arg_flag("-p", stack),

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ Deploy builds to a Rancher orchestrated stack using rancher-compose
 """
 import os
 
-import drone
 import subprocess
 
 
@@ -19,27 +18,19 @@ def str_to_bool(value):
 
 def main():
     """The main entrypoint for the plugin."""
-    payload = drone.plugin.get_input()
-    vargs = payload["vargs"]
-
-    # Change directory to deploy path
-    deploy_path = payload["workspace"]["path"]
-    os.chdir(deploy_path)
-
     # Optional fields
-    compose_file = vargs.get('compose_file')
-    rancher_file = vargs.get('rancher_file')
-    stack = vargs.get('stack', payload['repo']['name'])
-    services = vargs.get('services', '')
-    force_upgrade = str_to_bool(vargs.get('force', 'false'))
-    confirm_upgrade = str_to_bool(vargs.get('confirm', 'false'))
-    pull = str_to_bool(vargs.get('always_pull', 'false'))
+    compose_file = os.environ["PLUGIN_COMPOSE_FILE"]
+    rancher_file = os.environ["PLUGIN_RANCHER_FILE"]
+    stack = os.environ["DRONE_REPO_NAME"]
+    services = os.environ.get("PLUGIN_SERVICES", '')
+    force_upgrade = str_to_bool(os.environ.get('PLUGIN_FORCE', 'false'))
+    confirm_upgrade = str_to_bool(os.environ.get('PLUGIN_CONFIRM', 'false'))
+    pull = str_to_bool(os.environ.get('PLUGIN_ALWAYS_PULL', 'false'))
 
     # Set Required fields for rancher-compose to work
     # Should raise an error if they are not declared
-    os.environ["RANCHER_URL"] = vargs['url']
-    os.environ["RANCHER_ACCESS_KEY"] = vargs['access_key']
-    os.environ["RANCHER_SECRET_KEY"] = vargs['secret_key']
+    
+    os.environ["RANCHER_URL"] = os.environ.get('PLUGIN_URL')
 
     try:
         base_rancher_compose_cmd = \
@@ -68,8 +59,6 @@ def main():
     finally:
         # Unset environmental variables, no point in them hanging about
         del os.environ['RANCHER_URL']
-        del os.environ['RANCHER_ACCESS_KEY']
-        del os.environ['RANCHER_SECRET_KEY']
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
update baseimage to alpine: latest


> Versions of the Official Alpine Linux Docker images (since v3.3) contain a NULL password for the root user. This vulnerability appears to be the result of a regression introduced in December t2015. Due to the nature of this issue, systems deployed using affected versions of the Alpine Linux container that utilize Linux PAM, or some other mechanism that uses the system shadow file as an authentication database, may accept a NULL password for the root user.

> All supported builds have been updated and are "now only generated from upstream minirootfs tarballs," shows a commit from Natanael Copa, the creator of Alpine Linux. Release and update scripts have been refactored and moved to the official Alpine Linux image repository on the Docker portal.

[CISCO Talos official report]( https://talosintelligence.com/vulnerability_reports/TALOS-2019-0782)